### PR TITLE
Attribute "times" in animate element not valid

### DIFF
--- a/Examples/src/main/java/afester/javafx/examples/animation/counter/AnimatedCounter.java
+++ b/Examples/src/main/java/afester/javafx/examples/animation/counter/AnimatedCounter.java
@@ -16,8 +16,10 @@
 
 package afester.javafx.examples.animation.counter;
 
-import afester.javafx.examples.Example;
+import java.util.ArrayList;
+import java.util.List;
 
+import afester.javafx.examples.Example;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.application.Application;
@@ -30,9 +32,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 @Example(desc = "Animating a sequence of bitmap images", 

--- a/Examples/src/main/resources/afester/javafx/examples/data/Spinner-1s-200px.svg
+++ b/Examples/src/main/resources/afester/javafx/examples/data/Spinner-1s-200px.svg
@@ -1,0 +1,49 @@
+<svg class="lds-spinner" width="100%"  height="100%"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;"><g transform="rotate(0 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(30 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(60 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(90 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(120 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(150 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(180 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(210 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(240 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(270 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(300 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(330 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+  </rect>
+</g></svg>

--- a/Examples/src/main/resources/afester/javafx/examples/data/Spinner-1s-200px_2.svg
+++ b/Examples/src/main/resources/afester/javafx/examples/data/Spinner-1s-200px_2.svg
@@ -1,0 +1,49 @@
+<svg class="lds-spinner" width="100%"  height="100%"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;"><g transform="rotate(0 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(30 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(60 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(90 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(120 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(150 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(180 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(210 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(240 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(270 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(300 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(330 50 50)">
+  <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ff727d">
+    <animate attributeName="opacity" values="1;0"  dur="1s" begin="0s" repeatCount="indefinite"></animate>
+  </rect>
+</g></svg>

--- a/Examples/src/main/resources/afester/javafx/examples/data/data.lst
+++ b/Examples/src/main/resources/afester/javafx/examples/data/data.lst
@@ -1,4 +1,5 @@
 Spinner-1s-200px.svg
+hourglassLoader.svg
 Bmw_Z_Top_View_clip_art.svg
 Ghostscript_Tiger.svg
 Hammer.svg

--- a/Examples/src/main/resources/afester/javafx/examples/data/data.lst
+++ b/Examples/src/main/resources/afester/javafx/examples/data/data.lst
@@ -1,3 +1,4 @@
+Spinner-1s-200px.svg
 Bmw_Z_Top_View_clip_art.svg
 Ghostscript_Tiger.svg
 Hammer.svg

--- a/Examples/src/main/resources/afester/javafx/examples/data/hourglassLoader.svg
+++ b/Examples/src/main/resources/afester/javafx/examples/data/hourglassLoader.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+ xmlns="http://www.w3.org/2000/svg"
+ xmlns:svg="http://www.w3.org/2000/svg"
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ id="wrap" width="300" height="300">
+  
+  <!-- background -->
+  <svg>
+    <circle cx="150" cy="150" r="130" style="stroke: lightblue; stroke-width:18; fill:transparent"/>
+    <circle cx="150" cy="150" r="115" style="fill:#2c3e50"/>
+    <path style="stroke: #2c3e50; stroke-dasharray:820; stroke-dashoffset:820; stroke-width:18; fill:transparent" d="M150,150 m0,-130 a 130,130 0 0,1 0,260 a 130,130 0 0,1 0,-260">
+      <animate attributeName="stroke-dashoffset" dur="6s" to="-820" repeatCount="indefinite"/>
+    </path>
+  </svg>
+  
+  <!-- image -->
+  <svg>
+    <path id="hourglass" d="M150,150 C60,85 240,85 150,150 C60,215 240,215 150,150 Z" style="stroke: white; stroke-width:5; fill:white;" />
+    
+    <path id="frame" d="M100,97 L200, 97 M100,203 L200,203 M110,97 L110,142 M110,158 L110,200 M190,97 L190,142 M190,158 L190,200 M110,150 L110,150 M190,150 L190,150" style="stroke:lightblue; stroke-width:6; stroke-linecap:round" />
+    
+    <animateTransform xlink:href="#frame" attributeName="transform" type="rotate" begin="0s" dur="3s" values="0 150 150; 0 150 150; 180 150 150" keyTimes="0; 0.8; 1" repeatCount="indefinite" />
+    <animateTransform xlink:href="#hourglass" attributeName="transform" type="rotate" begin="0s" dur="3s" values="0 150 150; 0 150 150; 180 150 150" keyTimes="0; 0.8; 1" repeatCount="indefinite" />
+  </svg>
+  
+  <!-- sand -->
+  <svg>
+    <!-- upper part -->
+    <polygon id="upper" points="120,125 180,125 150,147" style="fill:#2c3e50;">
+      <animate attributeName="points" dur="3s" keyTimes="0; 0.8; 1" values="120,125 180,125 150,147; 150,150 150,150 150,150; 150,150 150,150 150,150" repeatCount="indefinite"/>
+    </polygon>
+    
+    <!-- falling sand -->
+    <path id="line" stroke-linecap="round" stroke-dasharray="1,4" stroke-dashoffset="200.00" stroke="#2c3e50" stroke-width="2" d="M150,150 L150,198">
+      <!-- running sand -->
+      <animate attributeName="stroke-dashoffset" dur="3s" to="1.00" repeatCount="indefinite"/>
+      <!-- emptied upper -->
+      <animate attributeName="d" dur="3s" to="M150,195 L150,195" values="M150,150 L150,198; M150,150 L150,198; M150,198 L150,198; M150,195 L150,195" keyTimes="0; 0.65; 0.9; 1" repeatCount="indefinite"/>
+      <!-- last drop -->
+      <animate attributeName="stroke" dur="3s" keyTimes="0; 0.65; 0.8; 1" values="#2c3e50;#2c3e50;transparent;transparent" to="transparent" repeatCount="indefinite"/>
+    </path>
+    
+    <!-- lower part -->
+    <g id="lower">
+      <path d="M150,180 L180,190 A28,10 0 1,1 120,190 L150,180 Z" style="stroke: transparent; stroke-width:5; fill:#2c3e50;">
+        <animateTransform attributeName="transform" type="translate" keyTimes="0; 0.65; 1" values="0 15; 0 0; 0 0" dur="3s" repeatCount="indefinite" />
+      </path>
+      <animateTransform xlink:href="#lower" attributeName="transform"
+                    type="rotate"
+                    begin="0s" dur="3s"
+                    values="0 150 150; 0 150 150; 180 150 150"
+                    keyTimes="0; 0.8; 1"
+                    repeatCount="indefinite"/>
+    </g>
+    
+    <!-- lower overlay - hourglass -->
+    <path d="M150,150 C60,85 240,85 150,150 C60,215 240,215 150,150 Z" style="stroke: white; stroke-width:5; fill:transparent;">
+      <animateTransform attributeName="transform"
+                    type="rotate"
+                    begin="0s" dur="3s"
+                    values="0 150 150; 0 150 150; 180 150 150"
+                    keyTimes="0; 0.8; 1"
+                    repeatCount="indefinite"/>
+    </path>
+    
+    <!-- lower overlay - frame -->
+    <path id="frame" d="M100,97 L200, 97 M100,203 L200,203" style="stroke:lightblue; stroke-width:6; stroke-linecap:round">
+      <animateTransform attributeName="transform"
+                    type="rotate"
+                    begin="0s" dur="3s"
+                    values="0 150 150; 0 150 150; 180 150 150"
+                    keyTimes="0; 0.8; 1"
+                    repeatCount="indefinite"/>
+    </path>
+  </svg>
+  
+</svg>

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgAnimation.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgAnimation.java
@@ -16,16 +16,23 @@
 
 package afester.javafx.svg;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.batik.anim.dom.SVGOMAnimateElement;
+import org.apache.batik.anim.dom.SVGOMElement;
 import org.apache.batik.parser.ClockParser;
+import org.w3c.dom.NodeList;
 
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.scene.Node;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Polygon;
+import javafx.scene.shape.Shape;
 import javafx.util.Duration;
 
 public class SvgAnimation {
@@ -35,7 +42,7 @@ public class SvgAnimation {
     private String attributeName;   // The attribute to animate
     // private String attributeType;
 
-    private double[] values;        // TODO: probably need to parameterize this type
+    private String[] values;        // TODO: probably need to parameterize this type
     private double by;              // TODO: probably need to parameterize this type
 
     private Long begin;             // TODO: can also be a list of start times
@@ -58,16 +65,23 @@ public class SvgAnimation {
         if (!valueList.equals("")) {
             // If a list of values is specified, any from, to and by attribute values are ignored.
             // By default, a simple linear interpolation is performed over the values, evenly spaced over the duration of the animation
-            String[] theValues = valueList.split(";");
-            values = new double[theValues.length];
-            for (int idx = 0;  idx < theValues.length;  idx++) {
-                values[idx] = Double.parseDouble(theValues[idx]);
-            }
+            values = valueList.split(";");  // each discrete value is separated by ';'
+            System.err.println(values);
         } else {
-            String from = element.getAttribute("from");             // start value for the attribute's value
-            String to = element.getAttribute("to");                 // end value for the attribute's value
-            values = new double[]{Double.parseDouble(from), Double.parseDouble(to) };
-            by = Double.parseDouble(element.getAttribute("by"));    // delta value for the attribute's value
+            String from = element.getAttribute("from").trim();      // start value for the attribute's value
+            if (from.equals("")) {                                  // from is optional
+                from = "0";
+            }
+
+            String to = element.getAttribute("to").trim();          // end value for the attribute's value
+            values = new String[] {from, to};
+
+            String byAttr = element.getAttribute("by");
+            if (byAttr.equals("")) {                                // by is optional
+                byAttr = "0";
+            }
+
+            by = Double.parseDouble(byAttr);    // delta value for the attribute's value
         }
 
         // <animate> animation timing attributes
@@ -84,6 +98,8 @@ public class SvgAnimation {
 
         //  String times = animate.getAttribute("times");           // Unsure - times is not an SVG animate attribute...
                                                                     // In Chrome, the sample runs also without this attribute.
+        
+        System.err.println(this);
     }
 
 
@@ -120,12 +136,15 @@ public class SvgAnimation {
         long offset = Long.MAX_VALUE;
 
         for (SvgAnimation animation : animations) {
-            offset = Math.min(offset, animation.begin);
+            offset = Math.min(offset, animation.begin != null ? animation.begin : 0);
             System.err.printf("%s - %s\n", offset, animation.begin);
         }
+
         if (offset != 0) {
             for (SvgAnimation animation : animations) {
-                animation.begin -= offset;
+                if (animation.begin != null) {
+                    animation.begin -= offset;
+                }
                 if (animation.end != null) {
                     animation.end -= offset;
                 }
@@ -133,6 +152,43 @@ public class SvgAnimation {
         }
     }
 
+//    private void nix() {
+//
+//        // now, each value can be of a simple type or of a complex type like color, list, ....
+//        // (probably this needs to be calculated depending on the attributeName)
+//        System.err.println(Arrays.toString(theValues));
+//        // values = new double[theValues.length];
+//        for (int idx = 0;  idx < theValues.length;  idx++) {
+//
+//            AnimationValue av = null;
+//            String[] list = theValues[idx].trim().split(" ");
+//            if (list.length == 1) {
+//                av = new AnimationValue(Double.parseDouble(list[0]));
+//            } else {
+//                for (int idx2 = 0;  idx2 < list.length;  idx2++) {
+//                    String[] tuple = list[idx].trim().split(",");
+//
+//                    if (tuple.length == 1) {
+//                        
+//                    } else {
+//                        List<Double> doubleValues = new ArrayList<>();
+//                        for (String e : tuple) {
+//                            doubleValues.add(Double.parseDouble(e));
+//                        }
+//                        animationValue = new AnimationValue(doubleValues);
+//                    }
+//                    theList.add(doubleValues);
+//                }
+//                av = new AnimationValue(theList);
+//            }
+//            System.err.println("VALUE:" + av);
+//
+//            // values2.add(theList);
+//            // System.err.println(theList);
+//            // values[idx] = Double.parseDouble(theValues[idx]);
+//        }
+//
+//    }
 
     /**
      * Creates a JavaFX timeline from this SvgAnimation.
@@ -140,17 +196,50 @@ public class SvgAnimation {
      * @return A JavaFX timeline object which corresponds to this SvgAnimation.
      */
     public Timeline createTimeline() {
-        KeyValue kv;
+        KeyValue kv = null;
         if (attributeName.equals("opacity")) {
-            node.setOpacity(values[0]);                           // start value
-            kv = new KeyValue(node.opacityProperty(), values[1]); // end value
+            System.err.println("opacity VALUES: " + Arrays.toString(values));
+            node.setOpacity(Double.parseDouble(values[0]));                           // start value  
+            kv = new KeyValue(node.opacityProperty(), Double.parseDouble(values[1])); // end value
+
+        } else if (attributeName.equals("stroke-dashoffset")) {
+            System.err.println("stroke-dashoffset VALUES: " + Arrays.toString(values));
+            Shape s = (Shape) node;
+            kv = new KeyValue(s.strokeDashOffsetProperty(), 1.0); // values[1]); // end value
+
+        } else if (attributeName.equals("stroke")) {
+            System.err.println("stroke VALUES: " + Arrays.toString(values));
+            Shape s = (Shape) node;
+            kv = new KeyValue(s.strokeProperty(), Color.ALICEBLUE);  // values[1]); // end value
+
+        } else if (attributeName.equals("points")) {
+            System.err.println("points VALUES: " + Arrays.toString(values));
+            Polygon p = (Polygon) node;        // points animations apply to a Polygon
+
+            // Animating the points of a polygon is not that trivial ... 
+            // kv = new KeyValue(p.getPoints(), 1.0); // values[1]); // end value
+
+            return null;
+
+        } else if (attributeName.equals("d")) {
+            System.err.println("d VALUES: " + Arrays.toString(values));
+            
+            // An SVG path in the JavaFX scene graph is either a Group of shapes or a JavaFX SVGPath 
+            // ...
+            // Animating the path elements a Path is not that trivial ... 
+            // kv = new KeyValue(p.getPoints(), 1.0); // values[1]); // end value
+
+            return null;
+
         } else {
             throw new RuntimeException("Unknown property " + attributeName);
         }
 
         KeyFrame kf = new KeyFrame(new Duration(duration), kv);     // Duration of the animation
         Timeline t = new Timeline(kf);
-        t.setDelay(new Duration(begin));                            // begin time
+        if (begin != null) {
+            t.setDelay(new Duration(begin));                            // begin time
+        }
         t.setCycleCount(repeatCount);                               // repeatCount
 
         return t;
@@ -162,5 +251,20 @@ public class SvgAnimation {
                              "             values=%s, by=%s,\n"+
                              "             begin=%s, end=%s, duration=%s, repeatCount=%s]",
                               attributeName, Arrays.toString(values), by, begin, end, duration, repeatCount);
+    }
+
+
+    public static Collection<? extends SvgAnimation> getAnimations(Node node, SVGOMElement element) {
+        List<SvgAnimation> result = new ArrayList<>();
+
+        // get the animate nodes for this element
+        NodeList children = element.getElementsByTagName("animate");
+        for (int idx = 0;  idx < children.getLength();  idx++) {
+            SVGOMAnimateElement animate = (SVGOMAnimateElement) children.item(idx);
+            SvgAnimation animation = new SvgAnimation(node, animate);
+            result.add(animation);
+        }
+
+        return result;
     }
 }

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgAnimation.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgAnimation.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2016 Andreas Fester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package afester.javafx.svg;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.batik.anim.dom.SVGOMAnimateElement;
+import org.apache.batik.parser.ClockParser;
+
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+import javafx.scene.Node;
+import javafx.util.Duration;
+
+public class SvgAnimation {
+
+    private Node node;              // The JavaFX node to animate
+
+    private String attributeName;   // The attribute to animate
+    // private String attributeType;
+
+    private double[] values;        // TODO: probably need to parameterize this type
+    private double by;              // TODO: probably need to parameterize this type
+
+    private Long begin;             // TODO: can also be a list of start times
+    private Long end;               // TODO: can also be a list of end times
+    private Long duration;          // duration in ms
+    private int repeatCount = 0;   // how often to repeat - Timeline.INFINITE is infinite times 
+
+
+    public SvgAnimation(Node node, SVGOMAnimateElement element) {
+        this.node = node;
+
+        // See https://www.w3.org/TR/SVG/animate.html#AnimateElement
+
+        // <animate> animation attribute target attributes
+        attributeName = element.getAttribute("attributeName");
+        // attributeType = element.getAttribute("attributeType");      //  "CSS | XML | auto"
+
+        // <animate> animation value attributes
+        String valueList = element.getAttribute("values");             // alternatively, a discrete set of values to apply
+        if (!valueList.equals("")) {
+            // If a list of values is specified, any from, to and by attribute values are ignored.
+            // By default, a simple linear interpolation is performed over the values, evenly spaced over the duration of the animation
+            String[] theValues = valueList.split(";");
+            values = new double[theValues.length];
+            for (int idx = 0;  idx < theValues.length;  idx++) {
+                values[idx] = Double.parseDouble(theValues[idx]);
+            }
+        } else {
+            String from = element.getAttribute("from");             // start value for the attribute's value
+            String to = element.getAttribute("to");                 // end value for the attribute's value
+            values = new double[]{Double.parseDouble(from), Double.parseDouble(to) };
+            by = Double.parseDouble(element.getAttribute("by"));    // delta value for the attribute's value
+        }
+
+        // <animate> animation timing attributes
+        begin = parseTime(element.getAttribute("begin"));           // Semicolon separated list of start times (currently only single value supported)
+        end = parseTime(element.getAttribute("end"));               // Semicolon separated list of end times (currently only single value supported)
+
+        duration = parseTime(element.getAttribute("dur"));          // duration of the animation
+        String repeatAttr = element.getAttribute("repeatCount");    // how often to repeat the animation
+        if (repeatAttr.equals("indefinite")) {
+            repeatCount = Timeline.INDEFINITE;
+        } else {
+            repeatCount = Integer.parseInt(repeatAttr);
+        }
+
+        //  String times = animate.getAttribute("times");           // Unsure - times is not an SVG animate attribute...
+                                                                    // In Chrome, the sample runs also without this attribute.
+    }
+
+
+    /**
+     * Returns the given time value in ms as a long value.
+     *
+     * @param timeValue The time value from an SVG animate attribute
+     * @return The corresponding time value in ms
+     */
+    private float result;
+
+    public Long parseTime(String timeValue) {
+        if (timeValue.equals("")) {
+            return null;
+        }
+
+        ClockParser p = new ClockParser(true);
+        p.setClockHandler(e -> result = e );        // TODO: does the parser consider units like s and ms? 
+                                                    // what is the result unit?
+        p.parse(timeValue);
+        return (long) (result * 1000);
+    }
+
+
+    /**
+     * Normalizes the begin and end times of each animation.
+     * The lowest begin time is considered an offset which is subtracted from all animations.
+     * This is required because svg:animate obviously allows negative timeline values, while
+     * JavaFX only allows positive timeline values.
+     * 
+     * @param animations
+     */
+    public static void normalize(List<SvgAnimation> animations) {
+        long offset = Long.MAX_VALUE;
+
+        for (SvgAnimation animation : animations) {
+            offset = Math.min(offset, animation.begin);
+            System.err.printf("%s - %s\n", offset, animation.begin);
+        }
+        if (offset != 0) {
+            for (SvgAnimation animation : animations) {
+                animation.begin -= offset;
+                if (animation.end != null) {
+                    animation.end -= offset;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Creates a JavaFX timeline from this SvgAnimation.
+     * 
+     * @return A JavaFX timeline object which corresponds to this SvgAnimation.
+     */
+    public Timeline createTimeline() {
+        KeyValue kv;
+        if (attributeName.equals("opacity")) {
+            node.setOpacity(values[0]);                           // start value
+            kv = new KeyValue(node.opacityProperty(), values[1]); // end value
+        } else {
+            throw new RuntimeException("Unknown property " + attributeName);
+        }
+
+        KeyFrame kf = new KeyFrame(new Duration(duration), kv);     // Duration of the animation
+        Timeline t = new Timeline(kf);
+        t.setDelay(new Duration(begin));                            // begin time
+        t.setCycleCount(repeatCount);                               // repeatCount
+
+        return t;
+    }
+
+    
+    public String toString() {
+        return String.format("SvgAnimation[attributeName=%s,\n"+
+                             "             values=%s, by=%s,\n"+
+                             "             begin=%s, end=%s, duration=%s, repeatCount=%s]",
+                              attributeName, Arrays.toString(values), by, begin, end, duration, repeatCount);
+    }
+}

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
@@ -52,6 +52,9 @@ import org.w3c.dom.svg.SVGPoint;
 import org.w3c.dom.svg.SVGPointList;
 import org.w3c.dom.svg.SVGRect;
 
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
 import javafx.scene.Group;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.LinearGradient;
@@ -69,6 +72,7 @@ import javafx.scene.shape.SVGPath;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Text;
 import javafx.scene.transform.Affine;
+import javafx.util.Duration;
 
 
 public class SvgBasicElementHandler {
@@ -137,6 +141,8 @@ public class SvgBasicElementHandler {
     }
 
 
+    List<Timeline> timeLines = new ArrayList<>();
+
     void handleElement(SVGOMRectElement element) {
         // Get attributes from SVG node
         float xpos = element.getX().getBaseVal().getValue();
@@ -173,7 +179,10 @@ public class SvgBasicElementHandler {
             String from = animate.getAttribute("from");                 // start value for the attribute's value
             String to = animate.getAttribute("to");                     // end value for the attribute's value
             String by = animate.getAttribute("by");                     // delta value for the attribute's value
-            String values = animate.getAttribute("values");             // alternatively, a discrete set of values to apply 
+            String values = animate.getAttribute("values");             // alternatively, a discrete set of values to apply
+            if (!values.equals("")) {
+                
+            }
             // If a list of values is specified, any from, to and by attribute values are ignored.
             // By default, a simple linear interpolation is performed over the values, evenly spaced over the duration of the animation
 
@@ -192,6 +201,18 @@ public class SvgBasicElementHandler {
                                attributeName, attributeType, 
                                from, to, by, values,
                                begin, end, dur, repeatCount);
+
+            // We need one separate Timeline for each <animate> element.
+            result.setOpacity(0.2);                                     // start value
+            KeyValue kv = new KeyValue(result.opacityProperty(), 0.0);  // end value
+
+            KeyFrame kf = new KeyFrame(new Duration(1000), kv);         // Duration of the animation
+            Timeline t = new Timeline(kf);
+            int beginMillis = (int) ( (Double.parseDouble(begin.substring(0, begin.length()-1))+1) * 1000);
+            t.setDelay(new Duration(beginMillis));                      // begin time
+            t.setCycleCount(Timeline.INDEFINITE);                       // repeatCount
+
+            timeLines.add(t);
         }
 
         loader.parentNode.getChildren().add(result);

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
@@ -52,9 +52,6 @@ import org.w3c.dom.svg.SVGPoint;
 import org.w3c.dom.svg.SVGPointList;
 import org.w3c.dom.svg.SVGRect;
 
-import javafx.animation.KeyFrame;
-import javafx.animation.KeyValue;
-import javafx.animation.Timeline;
 import javafx.scene.Group;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.LinearGradient;
@@ -72,7 +69,6 @@ import javafx.scene.shape.SVGPath;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Text;
 import javafx.scene.transform.Affine;
-import javafx.util.Duration;
 
 
 public class SvgBasicElementHandler {
@@ -141,7 +137,7 @@ public class SvgBasicElementHandler {
     }
 
 
-    List<Timeline> timeLines = new ArrayList<>();
+    List<SvgAnimation> animations = new ArrayList<>();
 
     void handleElement(SVGOMRectElement element) {
         // Get attributes from SVG node
@@ -168,51 +164,10 @@ public class SvgBasicElementHandler {
         // get the animate nodes for this element
         NodeList children = element.getElementsByTagName("animate");
         for (int idx = 0;  idx < children.getLength();  idx++) {
-            // See https://www.w3.org/TR/SVG/animate.html#AnimateElement
             SVGOMAnimateElement animate = (SVGOMAnimateElement) children.item(idx);
-
-            // <animate> animation attribute target attributes
-            String attributeName = animate.getAttribute("attributeName");
-            String attributeType = animate.getAttribute("attributeType");
-
-            // <animate> animation value attributes
-            String from = animate.getAttribute("from");                 // start value for the attribute's value
-            String to = animate.getAttribute("to");                     // end value for the attribute's value
-            String by = animate.getAttribute("by");                     // delta value for the attribute's value
-            String values = animate.getAttribute("values");             // alternatively, a discrete set of values to apply
-            if (!values.equals("")) {
-                
-            }
-            // If a list of values is specified, any from, to and by attribute values are ignored.
-            // By default, a simple linear interpolation is performed over the values, evenly spaced over the duration of the animation
-
-            // <animate> animation timing attributes
-            String begin = animate.getAttribute("begin");               // Semicolon separated list of start times
-            String end = animate.getAttribute("end");                   // Semicolon separated list of end times            
-            String dur = animate.getAttribute("dur");                   // duration of the animation
-            String repeatCount = animate.getAttribute("repeatCount");   // how often to repeat the animation
-
-            //  String times = animate.getAttribute("times");           // Unsure - times is not an SVG animate attribute...
-                                                                        // In Chrome, the sample runs also without this attribute.
-
-            System.err.printf("ANIMATE: %s(%s)\n"+
-                              "         %s to %s / by %s / values %s\n"+
-                              "         begin=[%s], end=[%s], dur=%s, rep=%s\n", 
-                               attributeName, attributeType, 
-                               from, to, by, values,
-                               begin, end, dur, repeatCount);
-
-            // We need one separate Timeline for each <animate> element.
-            result.setOpacity(0.2);                                     // start value
-            KeyValue kv = new KeyValue(result.opacityProperty(), 0.0);  // end value
-
-            KeyFrame kf = new KeyFrame(new Duration(1000), kv);         // Duration of the animation
-            Timeline t = new Timeline(kf);
-            int beginMillis = (int) ( (Double.parseDouble(begin.substring(0, begin.length()-1))+1) * 1000);
-            t.setDelay(new Duration(beginMillis));                      // begin time
-            t.setCycleCount(Timeline.INDEFINITE);                       // repeatCount
-
-            timeLines.add(t);
+            SvgAnimation animation = new SvgAnimation(result, animate);
+//            System.err.println(animation);
+            animations.add(animation);
         }
 
         loader.parentNode.getChildren().add(result);

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
@@ -16,24 +16,10 @@
 
 package afester.javafx.svg;
 
-import javafx.scene.Group;
-import javafx.scene.paint.Color;
-import javafx.scene.paint.LinearGradient;
-import javafx.scene.paint.Paint;
-import javafx.scene.paint.RadialGradient;
-import javafx.scene.paint.Stop;
-import javafx.scene.shape.Circle;
-import javafx.scene.shape.CubicCurve;
-import javafx.scene.shape.Ellipse;
-import javafx.scene.shape.Line;
-import javafx.scene.shape.Polygon;
-import javafx.scene.shape.Polyline;
-import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.SVGPath;
-import javafx.scene.shape.Shape;
-import javafx.scene.text.Text;
-import javafx.scene.transform.Affine;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.batik.anim.dom.SVGOMAnimateElement;
 import org.apache.batik.anim.dom.SVGOMAnimatedPathData;
 import org.apache.batik.anim.dom.SVGOMAnimatedPathData.BaseSVGPathSegList;
 import org.apache.batik.anim.dom.SVGOMCircleElement;
@@ -59,15 +45,30 @@ import org.apache.batik.css.dom.CSSOMValue;
 import org.apache.batik.dom.svg.SVGPathSegItem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.w3c.dom.NodeList;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSStyleDeclaration;
-import org.w3c.dom.svg.SVGRect;
 import org.w3c.dom.svg.SVGPoint;
 import org.w3c.dom.svg.SVGPointList;
+import org.w3c.dom.svg.SVGRect;
 
-import java.util.ArrayList;
-import java.util.List;
+import javafx.scene.Group;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.RadialGradient;
+import javafx.scene.paint.Stop;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.CubicCurve;
+import javafx.scene.shape.Ellipse;
+import javafx.scene.shape.Line;
+import javafx.scene.shape.Polygon;
+import javafx.scene.shape.Polyline;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.SVGPath;
+import javafx.scene.shape.Shape;
+import javafx.scene.text.Text;
+import javafx.scene.transform.Affine;
 
 
 public class SvgBasicElementHandler {
@@ -157,6 +158,41 @@ public class SvgBasicElementHandler {
         }
 
         styleTools.applyStyle(result, element);
+
+        // get the animate nodes for this element
+        NodeList children = element.getElementsByTagName("animate");
+        for (int idx = 0;  idx < children.getLength();  idx++) {
+            // See https://www.w3.org/TR/SVG/animate.html#AnimateElement
+            SVGOMAnimateElement animate = (SVGOMAnimateElement) children.item(idx);
+
+            // <animate> animation attribute target attributes
+            String attributeName = animate.getAttribute("attributeName");
+            String attributeType = animate.getAttribute("attributeType");
+
+            // <animate> animation value attributes
+            String from = animate.getAttribute("from");                 // start value for the attribute's value
+            String to = animate.getAttribute("to");                     // end value for the attribute's value
+            String by = animate.getAttribute("by");                     // delta value for the attribute's value
+            String values = animate.getAttribute("values");             // alternatively, a discrete set of values to apply 
+            // If a list of values is specified, any from, to and by attribute values are ignored.
+            // By default, a simple linear interpolation is performed over the values, evenly spaced over the duration of the animation
+
+            // <animate> animation timing attributes
+            String begin = animate.getAttribute("begin");               // Semicolon separated list of start times
+            String end = animate.getAttribute("end");                   // Semicolon separated list of end times            
+            String dur = animate.getAttribute("dur");                   // duration of the animation
+            String repeatCount = animate.getAttribute("repeatCount");   // how often to repeat the animation
+
+            //  String times = animate.getAttribute("times");           // Unsure - times is not an SVG animate attribute...
+                                                                        // In Chrome, the sample runs also without this attribute.
+
+            System.err.printf("ANIMATE: %s(%s)\n"+
+                              "         %s to %s / by %s / values %s\n"+
+                              "         begin=[%s], end=[%s], dur=%s, rep=%s\n", 
+                               attributeName, attributeType, 
+                               from, to, by, values,
+                               begin, end, dur, repeatCount);
+        }
 
         loader.parentNode.getChildren().add(result);
     }

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgBasicElementHandler.java
@@ -19,7 +19,6 @@ package afester.javafx.svg;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.batik.anim.dom.SVGOMAnimateElement;
 import org.apache.batik.anim.dom.SVGOMAnimatedPathData;
 import org.apache.batik.anim.dom.SVGOMAnimatedPathData.BaseSVGPathSegList;
 import org.apache.batik.anim.dom.SVGOMCircleElement;
@@ -45,7 +44,6 @@ import org.apache.batik.css.dom.CSSOMValue;
 import org.apache.batik.dom.svg.SVGPathSegItem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.NodeList;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSStyleDeclaration;
 import org.w3c.dom.svg.SVGPoint;
@@ -118,6 +116,8 @@ public class SvgBasicElementHandler {
             result.getTransforms().add(transformation);
         }
 
+        animations.addAll(SvgAnimation.getAnimations(result, element));
+
         loader.parentNode.getChildren().add(result);
         loader.parentNode = result;
     }
@@ -160,15 +160,8 @@ public class SvgBasicElementHandler {
         }
 
         styleTools.applyStyle(result, element);
-
-        // get the animate nodes for this element
-        NodeList children = element.getElementsByTagName("animate");
-        for (int idx = 0;  idx < children.getLength();  idx++) {
-            SVGOMAnimateElement animate = (SVGOMAnimateElement) children.item(idx);
-            SvgAnimation animation = new SvgAnimation(result, animate);
-//            System.err.println(animation);
-            animations.add(animation);
-        }
+        SvgAnimation.getAnimations(result, element);
+        animations.addAll(SvgAnimation.getAnimations(result, element));
 
         loader.parentNode.getChildren().add(result);
     }
@@ -310,6 +303,7 @@ public class SvgBasicElementHandler {
         }
 
         styleTools.applyStyle(result, element);
+        animations.addAll(SvgAnimation.getAnimations(result, element));
 
         loader.parentNode.getChildren().add(result);
     }
@@ -374,6 +368,7 @@ public class SvgBasicElementHandler {
         }
 
         styleTools.applyStyle(result, element);
+        animations.addAll(SvgAnimation.getAnimations(result, element));
 
         //fxObj.setStroke(Color.VIOLET);
         loader.parentNode.getChildren().add(result);
@@ -476,6 +471,8 @@ public class SvgBasicElementHandler {
 
                 result.getChildren().add(fxObj);
             }
+
+            animations.addAll(SvgAnimation.getAnimations(fxObj, element));
         }
 
         loader.parentNode.getChildren().add(result);

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
@@ -266,7 +266,9 @@ public class SvgLoader {
             System.err.println(animation);
             //timeLines.add(animation.createTimeline());
             Timeline timeLine = animation.createTimeline();     // TODO: manage the Timeline objects - they are tied to the JavaFX application Thread
-            timeLine.play();                                    // TODO: Is this safe? Do the timelines have a common time base?
+            if (timeLine != null) {
+                timeLine.play();                                    // TODO: Is this safe? Do the timelines have a common time base?
+            }
         }
 
 //        for (Timeline tl : timeLines) {

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
@@ -16,7 +16,12 @@
 
 package afester.javafx.svg;
 
-import javafx.scene.Group;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.anim.dom.SVGOMCircleElement;
@@ -47,12 +52,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.NodeList;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
+import javafx.scene.Group;
 
 
 public class SvgLoader {
@@ -99,6 +99,8 @@ public class SvgLoader {
         elementMap.put("linearGradient", e -> bh.handleElement((SVGOMLinearGradientElement) e));
         elementMap.put("radialGradient", e -> bh.handleElement((SVGOMRadialGradientElement) e));
         elementMap.put("stop", e -> { } );
+
+        elementMap.put("animate", e -> { } );   // handled as sub element of shapes
 
         /*
          * <title>

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
@@ -105,7 +105,7 @@ public class SvgLoader {
         /*
          * <title>
          * 
-         * <a> <altGlyph> <altGlyphDef> <altGlyphItem> <animate> <animateColor>
+         * <a> <altGlyph> <altGlyphDef> <altGlyphItem> <animateColor>
          * <animateMotion> <animateTransform> <clipPath> <color-profile>
          * <cursor> <desc> <filter> <feGaussianBlur> <feOffset>
          * <feSpecularLighting> <fePointLight> <feComposite> <feMerge>
@@ -231,6 +231,9 @@ public class SvgLoader {
 
         parentNode = new Group();
         handle(doc);
+        System.err.println("Playing 1...");
+        bh.timeLines.forEach(e -> e.play());
+
         return parentNode;
     }
 
@@ -251,6 +254,10 @@ public class SvgLoader {
 
         parentNode = new Group();
         handle(doc);
+        System.err.println("Playing 2...");
+        //System.err.println("FRAMES:" + bh.t.getKeyFrames().size());
+        //System.err.println("TOTAL: " + bh.t.getTotalDuration());
+        bh.timeLines.forEach(e -> e.play());
 
         return parentNode;
     }

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgLoader.java
@@ -52,6 +52,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.NodeList;
 
+import javafx.animation.Timeline;
 import javafx.scene.Group;
 
 
@@ -232,7 +233,7 @@ public class SvgLoader {
         parentNode = new Group();
         handle(doc);
         System.err.println("Playing 1...");
-        bh.timeLines.forEach(e -> e.play());
+//        bh.timeLines.forEach(e -> e.play());
 
         return parentNode;
     }
@@ -254,10 +255,23 @@ public class SvgLoader {
 
         parentNode = new Group();
         handle(doc);
+
         System.err.println("Playing 2...");
         //System.err.println("FRAMES:" + bh.t.getKeyFrames().size());
         //System.err.println("TOTAL: " + bh.t.getTotalDuration());
-        bh.timeLines.forEach(e -> e.play());
+
+        SvgAnimation.normalize(bh.animations);
+        //List<Timeline> timeLines = new ArrayList<>();
+        for (SvgAnimation animation : bh.animations) {
+            System.err.println(animation);
+            //timeLines.add(animation.createTimeline());
+            Timeline timeLine = animation.createTimeline();     // TODO: manage the Timeline objects - they are tied to the JavaFX application Thread
+            timeLine.play();                                    // TODO: Is this safe? Do the timelines have a common time base?
+        }
+
+//        for (Timeline tl : timeLines) {
+//            tl.play();
+//        }
 
         return parentNode;
     }

--- a/FranzXaver/src/main/java/afester/javafx/svg/SvgStyleTools.java
+++ b/FranzXaver/src/main/java/afester/javafx/svg/SvgStyleTools.java
@@ -16,12 +16,8 @@
 
 package afester.javafx.svg;
 
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
-import javafx.scene.shape.Shape;
-import javafx.scene.text.Font;
-import javafx.scene.text.Text;
-import javafx.scene.transform.Affine;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.batik.anim.dom.SVGOMSVGElement;
 import org.apache.batik.anim.dom.SVGStylableElement;
@@ -40,8 +36,12 @@ import org.w3c.dom.svg.SVGTransform;
 import org.w3c.dom.svg.SVGTransformList;
 import org.w3c.dom.svg.SVGTransformable;
 
-import java.util.HashMap;
-import java.util.Map;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+import javafx.scene.shape.Shape;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+import javafx.scene.transform.Affine;
 
 public class SvgStyleTools {
     private static final Logger logger = LogManager.getLogger();


### PR DESCRIPTION
From contact@loading.io

Hi Henri,

Yes, you are right. It is a typo, which should be corrected to "keyTimes".
It seems that omitting keyTimes in this case won't affect the final result at all, but I still added it. Thanks for reporting! :)


Cheers,
Kirby

